### PR TITLE
Add comprehensive automated test suite

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,42 @@
+import type { Config } from "jest";
+
+const config: Config = {
+  rootDir: ".",
+  testTimeout: 30000,
+  coveragePathIgnorePatterns: ["/node_modules/", "/.next/"],
+  projects: [
+    {
+      displayName: "unit",
+      preset: "ts-jest",
+      testEnvironment: "jsdom",
+      testMatch: ["<rootDir>/tests/unit/**/*.test.ts", "<rootDir>/tests/unit/**/*.test.tsx"],
+      setupFilesAfterEnv: ["<rootDir>/tests/setup/jest.setup.ts"],
+      moduleNameMapper: {
+        "^@/(.*)$": "<rootDir>/src/$1",
+      },
+      globals: {
+        "ts-jest": {
+          tsconfig: "<rootDir>/tsconfig.jest.json",
+          isolatedModules: true,
+        },
+      },
+    },
+    {
+      displayName: "integration",
+      preset: "ts-jest",
+      testEnvironment: "node",
+      testMatch: ["<rootDir>/tests/integration/**/*.test.ts"],
+      setupFilesAfterEnv: ["<rootDir>/tests/setup/integration.ts"],
+      moduleNameMapper: {
+        "^@/(.*)$": "<rootDir>/src/$1",
+      },
+      globals: {
+        "ts-jest": {
+          tsconfig: "<rootDir>/tsconfig.jest.json",
+        },
+      },
+    },
+  ],
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,11 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "jest",
+    "test:unit": "jest --selectProjects=unit",
+    "test:integration": "jest --selectProjects=integration",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
@@ -26,15 +30,24 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "latest",
+    "@playwright/test": "^1.49.1",
+    "@testing-library/dom": "^10.4.0",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.2.0",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/jest": "^29.5.14",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "15.5.4",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
     "prettier": "^3.6.2",
     "prisma": "^6.17.0",
     "tailwindcss": "^4",
+    "ts-jest": "^29.3.4",
     "tsx": "^4.20.6",
     "typescript": "^5"
   }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  timeout: 90000,
+  expect: {
+    timeout: 10000,
+  },
+  fullyParallel: false,
+  retries: process.env.CI ? 2 : 0,
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:3000",
+    trace: "retain-on-failure",
+    storageState: undefined,
+    video: "off",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: process.env.PLAYWRIGHT_WEB_SERVER_COMMAND ?? "pnpm dev",
+    url: process.env.PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:3000",
+    reuseExistingServer: !process.env.CI,
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: 120000,
+  },
+});

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,16 @@
+# Тестовый контур платформы «СтаффТехнолоджи»
+
+## Структура
+- `tests/unit` — unit-тесты утилит, компонентов и клиентских сценариев (Jest + React Testing Library).
+- `tests/integration` — интеграционные сценарии для серверных экшенов, авторизации и работы с Prisma.
+- `tests/e2e` — сквозные сценарии UI (Playwright).
+- `tests/setup` — конфигурация и общие хуки Jest.
+- `tests/utils` — вспомогательные утилиты для тестов (сброс базы данных и пр.).
+
+## Запуск
+1. Установите зависимости: `pnpm install`
+2. Прогон unit-тестов: `pnpm test:unit`
+3. Прогон интеграционных тестов: `pnpm test:integration`
+4. Сквозные тесты (предварительно запустите `pnpm prisma migrate deploy && pnpm prisma db seed`): `pnpm test:e2e`
+
+Общий прогон всех Jest-проектов: `pnpm test`

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from "@playwright/test";
+
+async function login(page, email: string, password: string) {
+  await page.goto("/auth/login");
+  await page.fill('input[name="email"]', email);
+  await page.fill('input[name="password"]', password);
+  await Promise.all([
+    page.waitForURL((url) => url.pathname === "/"),
+    page.click('button[type="submit"]'),
+  ]);
+}
+
+test.describe("Authentication", () => {
+  test("shows error with invalid credentials", async ({ page }) => {
+    await page.goto("/auth/login");
+    await page.fill('input[name="email"]', "wrong@example.com");
+    await page.fill('input[name="password"]', "wrongpass");
+    await page.click('button[type="submit"]');
+
+    await expect(page.getByText("Неверный email или пароль")).toBeVisible();
+  });
+
+  test("logs in applicant and shows dashboard stats", async ({ page }) => {
+    await login(page, "alex@example.com", "test123");
+
+    await expect(page.getByRole("heading", { name: "Технологичный найм: соединяем лучших специалистов с амбициозными компаниями" })).toBeVisible();
+
+    await page.goto("/applicant/dashboard");
+    await expect(page.getByRole("heading", { name: "Уведомления" })).toBeVisible();
+    await expect(page.getByText("Всего откликов")).toBeVisible();
+  });
+});

--- a/tests/e2e/dashboard.spec.ts
+++ b/tests/e2e/dashboard.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from "@playwright/test";
+
+async function login(page, email: string, password: string) {
+  await page.goto("/auth/login");
+  await page.fill('input[name="email"]', email);
+  await page.fill('input[name="password"]', password);
+  await Promise.all([
+    page.waitForURL("**/"),
+    page.click('button[type="submit"]'),
+  ]);
+}
+
+test.describe("Dashboards", () => {
+  test("admin dashboard shows stats and logs", async ({ page }) => {
+    await login(page, "admin@stafftech.ru", "admin123");
+
+    await page.goto("/admin/dashboard");
+    await expect(page.getByText("Всего пользователей")).toBeVisible();
+    await expect(page.getByText("Активные вакансии")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Системный журнал" })).toBeVisible();
+    await expect(page.getByText("Регистрация", { exact: false })).toBeVisible();
+  });
+});

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Navigation and search flows", () => {
+  test("navigates from landing to vacancies and shows filters", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByRole("heading", { name: /Технологичный найм/ })).toBeVisible();
+
+    await Promise.all([
+      page.waitForURL("**/jobs/search*"),
+      page.getByRole("link", { name: "Найти работу" }).click(),
+    ]);
+
+    await expect(page.getByRole("heading", { name: "Поиск вакансий" })).toBeVisible();
+    await expect(page.getByLabel("Поиск по вакансиям")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Фильтры" })).toBeVisible();
+    await expect(page.getByText("Frontend Developer")).toBeVisible();
+    await expect(page.getByRole("button", { name: /Откликнуться|Войдите как соискатель/ })).toBeVisible();
+  });
+
+  test("opens resume search and renders employer actions", async ({ page }) => {
+    await page.goto("/resumes/search");
+
+    await expect(page.getByRole("heading", { name: "Поиск резюме" })).toBeVisible();
+    await expect(page.getByText("Фильтры резюме")).toBeVisible();
+    await expect(page.getByPlaceholder(/Аналитика/)).toBeVisible();
+    await expect(page.getByRole("button", { name: /Пригласить|Доступно работодателям/ })).toBeVisible();
+  });
+});

--- a/tests/e2e/vacancy-resume.spec.ts
+++ b/tests/e2e/vacancy-resume.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from "@playwright/test";
+
+async function login(page, email: string, password: string) {
+  await page.goto("/auth/login");
+  await page.fill('input[name="email"]', email);
+  await page.fill('input[name="password"]', password);
+  await Promise.all([
+    page.waitForURL("**/"),
+    page.click('button[type="submit"]'),
+  ]);
+}
+
+test.describe("Employer and applicant flows", () => {
+  test("employer publishes a new vacancy", async ({ page }) => {
+    await login(page, "hr@techcorp.ru", "password123");
+
+    await page.goto("/employer/vacancies/new");
+    const title = `QA Lead ${Date.now()}`;
+
+    await page.fill('input[name="title"]', title);
+    await page.fill('textarea[name="description"]', "Отвечать за качество, автоматизацию и улучшение процессов.");
+    await page.fill('textarea[name="requirements"]', "5+ лет опыта, знание Playwright, TypeScript, CI/CD.");
+    await page.fill('textarea[name="conditions"]', "ДМС, удаленка 3/2, бонусы.");
+    await page.fill('input[name="city"]', "Москва");
+    await page.getByLabel("Тип занятости").selectOption("full_time");
+    await page.getByLabel("График").selectOption("remote");
+    await page.fill('input[name="salaryFrom"]', "210000");
+    await page.fill('input[name="salaryTo"]', "280000");
+
+    await Promise.all([
+      page.waitForURL("**/employer/vacancies"),
+      page.click('button[type="submit"]'),
+    ]);
+
+    await expect(page.getByRole("heading", { name: title })).toBeVisible();
+  });
+
+  test("applicant updates resume and sees new stats", async ({ page }) => {
+    await login(page, "alex@example.com", "test123");
+
+    await page.goto("/applicant/resume/edit");
+    const desiredPosition = `Automation QA ${Date.now()}`;
+
+    await page.fill('input[name="desiredPosition"]', desiredPosition);
+    await page.fill('input[name="city"]', "Санкт-Петербург");
+    await page.fill('input[name="expectedSalary"]', "190000");
+    await page.fill('textarea[name="summary"]', "Эксперт по автоматизации тестирования и CI/CD.");
+
+    await page.click('button:has-text("Сохранить резюме")');
+    await page.waitForTimeout(1000);
+
+    await page.goto("/applicant/dashboard");
+    await expect(page.getByText(desiredPosition)).toBeVisible();
+    await expect(page.getByText("190 000")).toBeVisible();
+  });
+});

--- a/tests/integration/admin.test.ts
+++ b/tests/integration/admin.test.ts
@@ -1,0 +1,84 @@
+import { createApplicationAction, createVacancyAction, registerApplicant, registerEmployer, updateApplicationStatus } from "@/shared/actions";
+import prisma from "@/shared/prisma";
+import { Role } from "@prisma/client";
+
+async function seedPlatformData() {
+  await registerApplicant({
+    lastName: "Сидоров",
+    firstName: "Павел",
+    patronymic: "Игоревич",
+    email: "pavel@applicant.ru",
+    phone: "+7 921 111-22-33",
+    password: "secret123",
+    desiredPosition: "DevOps",
+  });
+
+  await registerEmployer({
+    companyName: "Digital Lab",
+    inn: "7745123456",
+    email: "hr@digitallab.ru",
+    phone: "+7 495 321-12-12",
+    password: "secret321",
+  });
+
+  const employer = await prisma.user.findUnique({ where: { email: "hr@digitallab.ru" }, include: { company: true } });
+  const applicant = await prisma.user.findUnique({ where: { email: "pavel@applicant.ru" }, include: { resume: true } });
+
+  if (!employer?.company || !applicant?.resume) {
+    throw new Error("Failed to prepare base data");
+  }
+
+  await createVacancyAction({
+    employerId: employer.id,
+    title: "DevOps Engineer",
+    description: "Поддержка инфраструктуры",
+    requirements: "Kubernetes",
+    conditions: "Гибридный график",
+    city: "Москва",
+    employmentType: "full_time",
+    schedule: "hybrid",
+    salaryFrom: 200000,
+    salaryTo: 260000,
+  });
+
+  const vacancy = await prisma.vacancy.findFirst({ where: { employerId: employer.id } });
+  await createApplicationAction({ applicantId: applicant.id, vacancyId: vacancy!.id });
+
+  const application = await prisma.application.findFirst({ where: { applicantId: applicant.id } });
+  await updateApplicationStatus({ applicationId: application!.id, status: "hired" });
+}
+
+describe("Admin analytics", () => {
+  it("aggregates user roles, active vacancies and logs", async () => {
+    const admin = await prisma.user.create({
+      data: {
+        email: "admin@stafftech.ru",
+        password: "admin123",
+        firstName: "Admin",
+        lastName: "User",
+        role: Role.ADMIN,
+      },
+    });
+
+    await seedPlatformData();
+
+    const userCount = await prisma.user.count();
+    const applicants = await prisma.user.count({ where: { role: Role.APPLICANT } });
+    const employers = await prisma.user.count({ where: { role: Role.EMPLOYER } });
+    const activeVacancies = await prisma.vacancy.count({ where: { isActive: true } });
+    const hiredCount = await prisma.application.count({ where: { status: "hired" } });
+    const logs = await prisma.systemLog.findMany({ orderBy: { createdAt: "desc" }, take: 5 });
+
+    expect(userCount).toBeGreaterThanOrEqual(3);
+    expect(applicants).toBeGreaterThanOrEqual(1);
+    expect(employers).toBeGreaterThanOrEqual(1);
+    expect(activeVacancies).toBe(1);
+    expect(hiredCount).toBe(1);
+    expect(logs.some((log) => log.action.includes("Создана вакансия"))).toBe(true);
+    expect(logs.some((log) => log.action.includes("Статус отклика"))).toBe(true);
+
+    // Ensure admin record still present and unaffected by operations
+    const storedAdmin = await prisma.user.findUnique({ where: { email: admin.email } });
+    expect(storedAdmin?.role).toBe(Role.ADMIN);
+  });
+});

--- a/tests/integration/application.test.ts
+++ b/tests/integration/application.test.ts
@@ -1,0 +1,125 @@
+import { createApplicationAction, inviteApplicantToInterview, updateApplicationStatus } from "@/shared/actions";
+import prisma from "@/shared/prisma";
+import { ApplicationStatus, Role } from "@prisma/client";
+import { revalidatePath } from "next/cache";
+
+describe("Application actions", () => {
+  async function createBaseData() {
+    const employer = await prisma.user.create({
+      data: {
+        email: "employer@apps.ru",
+        password: "secret123",
+        firstName: "Елена",
+        lastName: "HR",
+        role: Role.EMPLOYER,
+        company: {
+          create: {
+            name: "Apps Corp",
+            inn: "7712345678",
+            email: "apps@corp.ru",
+          },
+        },
+        vacancies: {
+          create: [{
+            title: "Backend Developer",
+            description: "Создание микросервисов",
+            requirements: "Node.js",
+            conditions: "Опционы",
+            city: "Москва",
+            employmentType: "full_time",
+            schedule: "remote",
+            salaryFrom: 180000,
+            salaryTo: 250000,
+          }],
+        },
+      },
+      include: { vacancies: true },
+    });
+
+    const applicant = await prisma.user.create({
+      data: {
+        email: "candidate@apps.ru",
+        password: "candidate123",
+        firstName: "Михаил",
+        lastName: "Смирнов",
+        role: Role.APPLICANT,
+        resume: {
+          create: {
+            desiredPosition: "Backend Developer",
+            city: "Москва",
+            employmentType: "full_time",
+            skills: { create: [{ skill: "Node.js" }] },
+          },
+        },
+      },
+      include: { resume: true },
+    });
+
+    return { employer, applicant };
+  }
+
+  it("creates application using resume fallback and logs action", async () => {
+    const { employer, applicant } = await createBaseData();
+
+    await createApplicationAction({ applicantId: applicant.id, vacancyId: employer.vacancies[0].id });
+
+    const application = await prisma.application.findFirst({
+      where: { applicantId: applicant.id, vacancyId: employer.vacancies[0].id },
+    });
+
+    expect(application).toMatchObject({ status: ApplicationStatus.pending, resumeId: applicant.resume?.id ?? undefined });
+
+    const log = await prisma.systemLog.findFirst({ where: { action: "Создан отклик", userEmail: applicant.email } });
+    expect(log).not.toBeNull();
+
+    expect(revalidatePath).toHaveBeenCalledWith("/applicant/dashboard");
+    expect(revalidatePath).toHaveBeenCalledWith("/employer/dashboard");
+  });
+
+  it("updates application status, sends notification and logs", async () => {
+    const { employer, applicant } = await createBaseData();
+
+    const application = await prisma.application.create({
+      data: {
+        applicantId: applicant.id,
+        vacancyId: employer.vacancies[0].id,
+        resumeId: applicant.resume?.id!,
+        status: ApplicationStatus.pending,
+      },
+      include: { applicant: true },
+    });
+
+    await updateApplicationStatus({ applicationId: application.id, status: "invited" });
+
+    const updated = await prisma.application.findUnique({ where: { id: application.id } });
+    expect(updated?.status).toBe(ApplicationStatus.invited);
+
+    const notification = await prisma.notification.findFirst({ where: { userId: applicant.id } });
+    expect(notification?.title).toBe("Изменение статуса отклика");
+
+    const log = await prisma.systemLog.findFirst({ where: { action: { contains: "Статус отклика" } } });
+    expect(log?.userEmail).toBe(applicant.email);
+
+    expect(revalidatePath).toHaveBeenCalledWith("/employer/dashboard");
+    expect(revalidatePath).toHaveBeenCalledWith("/admin/dashboard");
+  });
+
+  it("invites applicant to interview using most recent vacancy", async () => {
+    const { employer, applicant } = await createBaseData();
+
+    await inviteApplicantToInterview({ employerId: employer.id, resumeId: applicant.resume?.id! });
+
+    const application = await prisma.application.findFirst({
+      where: { applicantId: applicant.id, status: ApplicationStatus.invited },
+      include: { vacancy: true },
+    });
+
+    expect(application?.vacancyId).toBe(employer.vacancies[0].id);
+
+    const notification = await prisma.notification.findFirst({ where: { userId: applicant.id, title: "Приглашение на собеседование" } });
+    expect(notification).not.toBeNull();
+
+    const log = await prisma.systemLog.findFirst({ where: { action: "Отправлено приглашение на собеседование" } });
+    expect(log?.userEmail).toBe(applicant.email);
+  });
+});

--- a/tests/integration/auth.test.ts
+++ b/tests/integration/auth.test.ts
@@ -1,0 +1,92 @@
+import { authOptions } from "@/shared/auth/options";
+import { registerApplicant, registerEmployer } from "@/shared/actions";
+import prisma from "@/shared/prisma";
+import { Role } from "@prisma/client";
+import { redirect } from "next/navigation";
+
+const credentialsProvider = authOptions.providers.find((provider) => provider.id === "credentials");
+
+if (!credentialsProvider || typeof credentialsProvider.authorize !== "function") {
+  throw new Error("Credentials provider is not configured");
+}
+
+describe("Auth actions", () => {
+  it("registers applicant with resume, notification and log", async () => {
+    await registerApplicant({
+      lastName: "Петров",
+      firstName: "Иван",
+      patronymic: "Сергеевич",
+      email: "ivan.petrov@example.com",
+      phone: "+7 900 123-45-67",
+      password: "password123",
+      desiredPosition: "QA Engineer",
+    });
+
+    const user = await prisma.user.findUnique({
+      where: { email: "ivan.petrov@example.com" },
+      include: { resume: true, notifications: true },
+    });
+
+    expect(user).toMatchObject({
+      role: Role.APPLICANT,
+      firstName: "Иван",
+      lastName: "Петров",
+    });
+    expect(user?.resume).toMatchObject({ desiredPosition: "QA Engineer" });
+    expect(user?.notifications).toHaveLength(1);
+    expect(redirect).toHaveBeenCalledWith("/auth/login?registered=applicant");
+
+    const log = await prisma.systemLog.findFirst({ where: { userEmail: "ivan.petrov@example.com" } });
+    expect(log?.action).toBe("Регистрация соискателя");
+  });
+
+  it("registers employer with company and system log", async () => {
+    await registerEmployer({
+      companyName: "Future LLC",
+      inn: "7708123456",
+      email: "hr@future.ru",
+      phone: "+7 921 555-44-33",
+      password: "password321",
+    });
+
+    const employer = await prisma.user.findUnique({
+      where: { email: "hr@future.ru" },
+      include: { company: true },
+    });
+
+    expect(employer?.role).toBe(Role.EMPLOYER);
+    expect(employer?.company?.name).toBe("Future LLC");
+    expect(redirect).toHaveBeenCalledWith("/auth/login?registered=employer");
+
+    const log = await prisma.systemLog.findFirst({ where: { action: "Регистрация работодателя" } });
+    expect(log?.userEmail).toBe("hr@future.ru");
+  });
+
+  it("authorizes valid credentials and rejects invalid ones", async () => {
+    const user = await prisma.user.create({
+      data: {
+        email: "qa@test.ru",
+        password: "secret123",
+        firstName: "QA",
+        lastName: "Engineer",
+        role: Role.APPLICANT,
+      },
+    });
+
+    const sessionUser = await credentialsProvider.authorize?.({ email: user.email, password: "secret123" });
+    expect(sessionUser).toMatchObject({ email: user.email, role: Role.APPLICANT });
+
+    const invalid = await credentialsProvider.authorize?.({ email: user.email, password: "wrong" });
+    expect(invalid).toBeNull();
+  });
+
+  it("adds role and id into session callback", async () => {
+    const session = await authOptions.callbacks?.session?.({
+      session: { user: { name: "QA", email: "qa@test.ru" } } as never,
+      token: { sub: "42", role: Role.ADMIN } as never,
+    });
+
+    expect(session?.user?.id).toBe("42");
+    expect(session?.user?.role).toBe(Role.ADMIN);
+  });
+});

--- a/tests/integration/resume.test.ts
+++ b/tests/integration/resume.test.ts
@@ -1,0 +1,88 @@
+import { saveResumeAction } from "@/shared/actions";
+import prisma from "@/shared/prisma";
+import { Role } from "@prisma/client";
+import { revalidatePath } from "next/cache";
+
+describe("Resume actions", () => {
+  it("updates resume details, replaces education & experience and logs action", async () => {
+    const applicant = await prisma.user.create({
+      data: {
+        email: "resume@applicant.ru",
+        password: "secret123",
+        firstName: "Алексей",
+        lastName: "Иванов",
+        role: Role.APPLICANT,
+        resume: {
+          create: {
+            desiredPosition: "Junior QA",
+            city: "Казань",
+            summary: "Начинающий тестировщик",
+            employmentType: "full_time",
+            education: { create: [{ institution: "КФУ" }] },
+            experience: {
+              create: [{
+                company: "StartUp",
+                position: "Intern",
+                startDate: new Date("2023-01-01"),
+                endDate: new Date("2023-06-01"),
+              }],
+            },
+            skills: { create: [{ skill: "Manual QA" }] },
+          },
+        },
+      },
+      include: { resume: true },
+    });
+
+    const resume = applicant.resume!;
+
+    await saveResumeAction({
+      resumeId: resume.id,
+      desiredPosition: "Senior QA",
+      city: "Москва",
+      summary: "Автоматизатор тестирования",
+      expectedSalary: 200000,
+      employmentType: "full_time",
+      skills: ["Playwright", "TypeScript"],
+      education: [
+        {
+          institution: "МГУ",
+          degree: "Магистр",
+          field: "Прикладная математика",
+          startYear: 2014,
+          endYear: 2020,
+        },
+      ],
+      experience: [
+        {
+          company: "Enterprise",
+          position: "QA Lead",
+          description: "Управление командой",
+          startDate: "2021-01-01",
+          endDate: "2023-12-01",
+        },
+      ],
+    });
+
+    const updated = await prisma.resume.findUnique({
+      where: { id: resume.id },
+      include: { education: true, experience: true },
+    });
+
+    expect(updated).toMatchObject({
+      desiredPosition: "Senior QA",
+      city: "Москва",
+      expectedSalary: 200000,
+    });
+    expect(updated?.education).toHaveLength(1);
+    expect(updated?.education?.[0]).toMatchObject({ institution: "МГУ", degree: "Магистр" });
+    expect(updated?.experience).toHaveLength(1);
+    expect(updated?.experience?.[0]).toMatchObject({ company: "Enterprise", position: "QA Lead" });
+
+    const log = await prisma.systemLog.findFirst({ where: { action: "Обновлено резюме", userEmail: applicant.email } });
+    expect(log).not.toBeNull();
+
+    expect(revalidatePath).toHaveBeenCalledWith("/applicant/dashboard");
+    expect(revalidatePath).toHaveBeenCalledWith("/applicant/resume/edit");
+  });
+});

--- a/tests/integration/vacancy.test.ts
+++ b/tests/integration/vacancy.test.ts
@@ -1,0 +1,96 @@
+import { createVacancyAction, toggleVacancyStatus } from "@/shared/actions";
+import prisma from "@/shared/prisma";
+import { Role } from "@prisma/client";
+import { redirect } from "next/navigation";
+import { revalidatePath } from "next/cache";
+
+describe("Vacancy actions", () => {
+  it("creates vacancy linked to employer company and logs action", async () => {
+    const employer = await prisma.user.create({
+      data: {
+        email: "employer@company.ru",
+        password: "secret123",
+        firstName: "Анна",
+        lastName: "HR",
+        role: Role.EMPLOYER,
+        company: {
+          create: {
+            name: "Company LLC",
+            inn: "7701234567",
+            email: "info@company.ru",
+            phone: "+7 495 123-45-67",
+          },
+        },
+      },
+      include: { company: true },
+    });
+
+    await createVacancyAction({
+      employerId: employer.id,
+      title: "QA Lead",
+      description: "Внедрение автоматизации",
+      requirements: "Опыт 5+ лет",
+      conditions: "ДМС и опции",
+      city: "Москва",
+      employmentType: "full_time",
+      schedule: "hybrid",
+      salaryFrom: 180000,
+      salaryTo: 240000,
+    });
+
+    const vacancy = await prisma.vacancy.findFirst({
+      where: { employerId: employer.id },
+    });
+
+    expect(vacancy).toMatchObject({
+      title: "QA Lead",
+      companyId: employer.company?.id,
+      salaryFrom: 180000,
+      salaryTo: 240000,
+    });
+
+    const log = await prisma.systemLog.findFirst({ where: { action: { contains: "Создана вакансия" } } });
+    expect(log?.userEmail).toBe(employer.email);
+
+    expect(redirect).toHaveBeenCalledWith("/employer/vacancies");
+    expect(revalidatePath).toHaveBeenCalledWith("/employer/dashboard");
+    expect(revalidatePath).toHaveBeenCalledWith("/employer/vacancies");
+  });
+
+  it("toggles vacancy status", async () => {
+    const employer = await prisma.user.create({
+      data: {
+        email: "status@company.ru",
+        password: "secret123",
+        firstName: "Сергей",
+        lastName: "HR",
+        role: Role.EMPLOYER,
+        company: {
+          create: {
+            name: "Status Corp",
+            inn: "7734567890",
+            email: "contact@status.ru",
+          },
+        },
+        vacancies: {
+          create: [{
+            title: "Frontend Developer",
+            description: "Развитие фронтенда",
+            requirements: "React",
+            conditions: "Удаленно",
+            city: "Казань",
+            salaryFrom: 120000,
+            salaryTo: 150000,
+          }],
+        },
+      },
+      include: { vacancies: true },
+    });
+
+    const vacancy = employer.vacancies[0];
+    await toggleVacancyStatus(vacancy.id, false);
+
+    const updated = await prisma.vacancy.findUnique({ where: { id: vacancy.id } });
+    expect(updated?.isActive).toBe(false);
+  });
+});

--- a/tests/setup/integration.ts
+++ b/tests/setup/integration.ts
@@ -1,0 +1,20 @@
+import prisma from "@/shared/prisma";
+import { resetDatabase } from "../utils/reset-db";
+
+jest.mock("next/navigation", () => ({
+  redirect: jest.fn(),
+}));
+
+jest.mock("next/cache", () => ({
+  revalidatePath: jest.fn(),
+}));
+
+beforeEach(async () => {
+  await resetDatabase();
+  jest.clearAllMocks();
+});
+
+afterAll(async () => {
+  await resetDatabase();
+  await prisma.$disconnect();
+});

--- a/tests/setup/jest.setup.ts
+++ b/tests/setup/jest.setup.ts
@@ -1,0 +1,43 @@
+import "@testing-library/jest-dom";
+import { TextEncoder, TextDecoder } from "util";
+
+// Polyfill TextEncoder/Decoder for jsdom environment
+if (!(global as typeof globalThis).TextEncoder) {
+  (global as typeof globalThis).TextEncoder = TextEncoder as never;
+}
+if (!(global as typeof globalThis).TextDecoder) {
+  (global as typeof globalThis).TextDecoder = TextDecoder as never;
+}
+
+const pushMock = jest.fn();
+const replaceMock = jest.fn();
+const prefetchMock = jest.fn();
+const backMock = jest.fn();
+
+const useRouterMock = jest.fn(() => ({
+  push: pushMock,
+  replace: replaceMock,
+  prefetch: prefetchMock,
+  back: backMock,
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: useRouterMock,
+  useSearchParams: jest.fn(() => new URLSearchParams()),
+  redirect: jest.fn(),
+  revalidatePath: jest.fn(),
+}));
+
+jest.mock("next/cache", () => ({
+  revalidatePath: jest.fn(),
+}));
+
+beforeEach(() => {
+  pushMock.mockClear();
+  replaceMock.mockClear();
+  prefetchMock.mockClear();
+  backMock.mockClear();
+  jest.clearAllMocks();
+});
+
+export { useRouterMock };

--- a/tests/unit/components/button.test.tsx
+++ b/tests/unit/components/button.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { Button } from "@/shared/ui/button";
+
+describe("Button", () => {
+  it("renders children and triggers click", () => {
+    const handleClick = jest.fn();
+    render(<Button onClick={handleClick}>Найти работу</Button>);
+
+    fireEvent.click(screen.getByRole("button", { name: "Найти работу" }));
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows loading state and disables button", () => {
+    render(
+      <Button loading variant="secondary">
+        Сохранить
+      </Button>,
+    );
+
+    const button = screen.getByRole("button", { name: "Загрузка..." });
+    expect(button).toBeDisabled();
+    expect(button).toHaveClass("bg-slate-100");
+  });
+});

--- a/tests/unit/components/filters-sheet.test.tsx
+++ b/tests/unit/components/filters-sheet.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { FiltersSheet } from "@/shared/ui/filters-sheet";
+
+describe("FiltersSheet", () => {
+  it("opens and closes dialog with provided content", async () => {
+    const user = userEvent.setup();
+    render(
+      <FiltersSheet title="Фильтры вакансий" triggerLabel="Открыть">
+        <div>Содержимое фильтров</div>
+      </FiltersSheet>,
+    );
+
+    const trigger = screen.getByRole("button", { name: /Открыть/i });
+    await user.click(trigger);
+
+    expect(screen.getByText("Фильтры вакансий")).toBeInTheDocument();
+    expect(screen.getByText("Содержимое фильтров")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Закрыть" }));
+
+    expect(screen.queryByText("Содержимое фильтров")).not.toBeInTheDocument();
+  });
+});

--- a/tests/unit/components/input.test.tsx
+++ b/tests/unit/components/input.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { Input } from "@/shared/ui/input";
+
+describe("Input", () => {
+  it("renders label, helper text and handles input", async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+
+    render(
+      <Input
+        label="Поиск"
+        placeholder="Введите запрос"
+        helperText="Можно вводить ключевые слова"
+        onChange={onChange}
+      />,
+    );
+
+    const input = screen.getByPlaceholderText("Введите запрос");
+    expect(screen.getByText("Поиск")).toBeInTheDocument();
+    expect(screen.getByText("Можно вводить ключевые слова")).toBeInTheDocument();
+
+    await user.type(input, "React");
+
+    expect(onChange).toHaveBeenCalled();
+    expect(input).toHaveValue("React");
+  });
+
+  it("renders error text with red color", () => {
+    render(<Input label="Email" error="Некорректный email" />);
+
+    const error = screen.getByText("Некорректный email");
+    expect(error).toHaveClass("text-red-500");
+  });
+});

--- a/tests/unit/components/jobs-search-client.test.tsx
+++ b/tests/unit/components/jobs-search-client.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useRouter } from "next/navigation";
+
+import { JobsSearchClient } from "@/app/jobs/search/search-client";
+import { formatCurrency } from "@/shared/lib/utils";
+
+jest.mock("@/shared/actions", () => ({
+  createApplicationAction: jest.fn().mockResolvedValue(undefined),
+}));
+
+const { createApplicationAction } = jest.requireMock("@/shared/actions");
+
+describe("JobsSearchClient", () => {
+  const baseVacancy = {
+    id: 1,
+    title: "Senior React Developer",
+    specialization: "Frontend",
+    description: "Работа над интерфейсом", 
+    requirements: "React, TypeScript",
+    conditions: "Удалённая работа",
+    city: "Москва",
+    employmentType: "full_time",
+    schedule: "remote",
+    salaryFrom: 150000,
+    salaryTo: 220000,
+    isActive: true,
+    createdAt: new Date("2024-01-10"),
+    updatedAt: new Date("2024-01-11"),
+    employerId: 10,
+    companyId: 5,
+    company: { id: 5, name: "TechCorp", inn: "123", email: "corp@tech", phone: "+7", description: "", userId: 0 },
+    applications: [],
+  } as const;
+
+  const defaultFilters = {
+    q: "",
+    city: "",
+    specialization: "",
+    employmentType: "",
+    schedule: "",
+    salaryFrom: "",
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders vacancy card with formatted data", () => {
+    render(
+      <JobsSearchClient
+        vacancies={[baseVacancy]}
+        cities={["Москва"]}
+        specializations={["Frontend"]}
+        applicantId={123}
+        initialFilters={defaultFilters}
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: "Поиск вакансий" })).toBeInTheDocument();
+    expect(screen.getByText("Senior React Developer")).toBeInTheDocument();
+    expect(screen.getByText(/TechCorp/)).toBeInTheDocument();
+    expect(screen.getByText(`${formatCurrency(baseVacancy.salaryFrom)} — ${formatCurrency(baseVacancy.salaryTo)}`)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Откликнуться" })).toBeEnabled();
+  });
+
+  it("calls server action when applicant clicks apply", async () => {
+    const user = userEvent.setup();
+    render(
+      <JobsSearchClient
+        vacancies={[baseVacancy]}
+        cities={["Москва"]}
+        specializations={["Frontend"]}
+        applicantId={321}
+        initialFilters={defaultFilters}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "Откликнуться" });
+    await user.click(button);
+
+    expect(createApplicationAction).toHaveBeenCalledWith({ applicantId: 321, vacancyId: baseVacancy.id });
+  });
+
+  it("prevents applying when user is anonymous", async () => {
+    const user = userEvent.setup();
+    render(
+      <JobsSearchClient
+        vacancies={[baseVacancy]}
+        cities={["Москва"]}
+        specializations={["Frontend"]}
+        applicantId={null}
+        initialFilters={defaultFilters}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "Войдите как соискатель" });
+    await user.click(button);
+
+    expect(createApplicationAction).not.toHaveBeenCalled();
+  });
+
+  it("applies filters and pushes query to router", async () => {
+    const user = userEvent.setup();
+    const push = jest.fn();
+    (useRouter as jest.Mock).mockReturnValue({ push });
+
+    render(
+      <JobsSearchClient
+        vacancies={[baseVacancy]}
+        cities={["Москва", "Казань"]}
+        specializations={["Frontend", "Backend"]}
+        applicantId={null}
+        initialFilters={defaultFilters}
+      />,
+    );
+
+    const citySelect = screen.getAllByLabelText("Город")[0];
+    await user.selectOptions(citySelect, "Казань");
+
+    expect(push).toHaveBeenCalledWith(expect.stringContaining("city=%D0%9A%D0%B0%D0%B7%D0%B0%D0%BD%D1%8C"));
+
+    const salaryInput = screen.getByLabelText("Зарплата от");
+    await user.clear(salaryInput);
+    await user.type(salaryInput, "180000");
+    await user.tab();
+
+    expect(push).toHaveBeenLastCalledWith(expect.stringContaining("salaryFrom=180000"));
+  });
+});

--- a/tests/unit/hooks/resumes-search-client.test.tsx
+++ b/tests/unit/hooks/resumes-search-client.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useRouter } from "next/navigation";
+
+import { ResumesSearchClient } from "@/app/resumes/search/search-client";
+
+jest.mock("@/shared/actions", () => ({
+  inviteApplicantToInterview: jest.fn().mockResolvedValue(undefined),
+}));
+
+const { inviteApplicantToInterview } = jest.requireMock("@/shared/actions");
+
+describe("ResumesSearchClient filters and actions", () => {
+  const baseResume = {
+    id: 11,
+    userId: 55,
+    desiredPosition: "Data Analyst",
+    summary: "Опыт анализа данных",
+    city: "Москва",
+    expectedSalary: 120000,
+    employmentType: "full_time",
+    createdAt: new Date("2024-01-12"),
+    updatedAt: new Date("2024-01-12"),
+    experience: [
+      {
+        id: 1,
+        resumeId: 11,
+        company: "FinData",
+        position: "Analyst",
+        description: null,
+        startDate: new Date("2022-01-01"),
+        endDate: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ],
+    education: [],
+    skills: [{ skill: "SQL" }, { skill: "Python" }],
+    user: { id: 55, firstName: "Мария", lastName: "Кузнецова", phone: "+7" },
+  } as const;
+
+  const initialFilters = { q: "", profession: "", experience: [] as (string | undefined)[] };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("pushes query params when filters change", async () => {
+    const user = userEvent.setup();
+    const push = jest.fn();
+    (useRouter as jest.Mock).mockReturnValue({ push });
+
+    render(
+      <ResumesSearchClient
+        resumes={[baseResume]}
+        employerId={null}
+        initialFilters={initialFilters}
+      />,
+    );
+
+    await user.type(screen.getByPlaceholderText(/Аналитика/i), "Product Manager");
+    await user.click(screen.getByRole("checkbox", { name: "1–3 года" }));
+    await user.click(screen.getByRole("button", { name: "Сохранить" }));
+
+    expect(push).toHaveBeenCalledWith(expect.stringContaining("profession=Product%20Manager"));
+    expect(push).toHaveBeenCalledWith(expect.stringContaining("experience=1-3"));
+  });
+
+  it("invites applicant when employer clicks CTA", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ResumesSearchClient
+        resumes={[baseResume]}
+        employerId={42}
+        initialFilters={initialFilters}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Пригласить на собеседование" }));
+
+    expect(inviteApplicantToInterview).toHaveBeenCalledWith({ employerId: 42, resumeId: baseResume.id });
+  });
+
+  it("disables invite button for guests", () => {
+    render(
+      <ResumesSearchClient
+        resumes={[baseResume]}
+        employerId={null}
+        initialFilters={initialFilters}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Доступно работодателям" })).toBeDisabled();
+  });
+});

--- a/tests/unit/hooks/use-auth-session.test.tsx
+++ b/tests/unit/hooks/use-auth-session.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+
+import { Providers } from "@/app/providers";
+
+jest.mock("next-auth/react", () => ({
+  SessionProvider: ({ children }: { children: React.ReactNode }) => <div data-testid="session-provider">{children}</div>,
+}));
+
+describe("Providers", () => {
+  it("wraps children with SessionProvider", () => {
+    render(
+      <Providers>
+        <span>Контент</span>
+      </Providers>,
+    );
+
+    const container = screen.getByTestId("session-provider");
+    expect(container).toBeInTheDocument();
+    expect(container).toHaveTextContent("Контент");
+  });
+});

--- a/tests/unit/utils/utils.test.ts
+++ b/tests/unit/utils/utils.test.ts
@@ -1,0 +1,44 @@
+import { cn, formatCurrency, formatDate } from "@/shared/lib/utils";
+
+describe("utils", () => {
+  describe("cn", () => {
+    it("merges class names and removes duplicates", () => {
+      expect(cn("btn", false && "hidden", "btn", "active")).toBe("btn active");
+    });
+  });
+
+  describe("formatCurrency", () => {
+    it("formats numbers with ₽ and grouping", () => {
+      const formatted = new Intl.NumberFormat("ru-RU", {
+        style: "currency",
+        currency: "RUB",
+        maximumFractionDigits: 0,
+      }).format(125000);
+      expect(formatCurrency(125000)).toBe(formatted);
+    });
+
+    it("returns fallback for undefined values", () => {
+      expect(formatCurrency(undefined)).toBe("По договорённости");
+    });
+
+    it("keeps zero value", () => {
+      expect(formatCurrency(0)).toBe("0\u00A0₽");
+    });
+  });
+
+  describe("formatDate", () => {
+    it("formats date instances", () => {
+      const date = new Date("2024-02-10T12:00:00Z");
+      expect(formatDate(date)).toMatch(/10\sфев\.?\s2024/i);
+    });
+
+    it("formats ISO strings", () => {
+      expect(formatDate("2023-08-01T00:00:00.000Z")).toMatch(/01\sавг\.?\s2023/i);
+    });
+
+    it("returns empty string for nullish", () => {
+      expect(formatDate(null)).toBe("");
+      expect(formatDate(undefined)).toBe("");
+    });
+  });
+});

--- a/tests/utils/reset-db.ts
+++ b/tests/utils/reset-db.ts
@@ -1,0 +1,16 @@
+import prisma from "@/shared/prisma";
+
+export async function resetDatabase() {
+  await prisma.$transaction([
+    prisma.notification.deleteMany(),
+    prisma.application.deleteMany(),
+    prisma.skill.deleteMany(),
+    prisma.experience.deleteMany(),
+    prisma.education.deleteMany(),
+    prisma.resume.deleteMany(),
+    prisma.vacancy.deleteMany(),
+    prisma.company.deleteMany(),
+    prisma.systemLog.deleteMany(),
+    prisma.user.deleteMany(),
+  ]);
+}

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "jsx": "react-jsx",
+    "allowJs": true,
+    "esModuleInterop": true,
+    "noEmit": false,
+    "types": ["jest", "node"]
+  },
+  "include": ["tests", "src", "jest.setup.ts", "tests/setup/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add Jest multi-project configuration with shared setup for client and server tests
- cover utilities, UI components, hooks, and Prisma-backed actions with unit and integration specs
- configure Playwright and author end-to-end scenarios for auth, navigation, dashboards, and CRUD flows
- document test structure and commands in tests/README.md

## Testing
- Not run (dependencies unavailable in execution environment)

------
https://chatgpt.com/codex/tasks/task_b_68e612e60e2c83298d0fef7a66758edf