### PR TITLE
Add application status management and invitation responses

### DIFF
--- a/src/app/applicant/dashboard/application-response-buttons.tsx
+++ b/src/app/applicant/dashboard/application-response-buttons.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useTransition } from "react";
+
+import { respondToInterviewInvitation } from "@/shared/actions";
+import { Button } from "@/shared/ui";
+
+interface ApplicationResponseButtonsProps {
+  applicationId: number;
+  applicantId: number;
+}
+
+export function ApplicationResponseButtons({
+  applicationId,
+  applicantId,
+}: ApplicationResponseButtonsProps) {
+  const [isPending, startTransition] = useTransition();
+
+  const respond = (decision: "accept" | "decline") => {
+    startTransition(async () => {
+      await respondToInterviewInvitation({
+        applicationId,
+        applicantId,
+        decision,
+      });
+    });
+  };
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      <Button
+        size="sm"
+        loading={isPending}
+        onClick={() => respond("accept")}
+      >
+        Согласиться
+      </Button>
+      <Button
+        size="sm"
+        variant="secondary"
+        loading={isPending}
+        onClick={() => respond("decline")}
+      >
+        Отказаться
+      </Button>
+    </div>
+  );
+}

--- a/src/app/applicant/resume/edit/page.tsx
+++ b/src/app/applicant/resume/edit/page.tsx
@@ -10,16 +10,31 @@ export default async function ResumeEditPage() {
   if (!session?.user?.id) {
     redirect("/auth/login");
   }
-  const resume = await prisma.resume.findUnique({
-    where: { userId: Number(session.user.id) },
+
+  const userId = Number(session.user.id);
+  let resume = await prisma.resume.findUnique({
+    where: { userId },
     include: {
       education: true,
       experience: true,
+      skills: true,
     },
   });
 
   if (!resume) {
-    redirect("/applicant/dashboard");
+    resume = await prisma.resume.create({
+      data: {
+        userId,
+        desiredPosition: "Специалист",
+        city: "",
+        summary: "",
+      },
+      include: {
+        education: true,
+        experience: true,
+        skills: true,
+      },
+    });
   }
 
   return <ResumeEditor resume={resume} />;

--- a/src/app/applicant/resume/edit/resume-editor.tsx
+++ b/src/app/applicant/resume/edit/resume-editor.tsx
@@ -4,7 +4,7 @@ import { useTransition } from "react";
 import { useFieldArray, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import type { Education, Experience, Resume } from "@prisma/client";
+import type { Education, Experience, Resume, Skill } from "@prisma/client";
 
 import { saveResumeAction } from "@/shared/actions";
 import { Button, Card, ChipInput, Input, Select } from "@/shared/ui";
@@ -50,7 +50,7 @@ const schema = z.object({
 type FormValues = z.infer<typeof schema>;
 
 interface ResumeEditorProps {
-  resume: Resume & { education: Education[]; experience: Experience[] };
+  resume: Resume & { education: Education[]; experience: Experience[]; skills: Skill[] };
 }
 
 export function ResumeEditor({ resume }: ResumeEditorProps) {
@@ -66,7 +66,9 @@ export function ResumeEditor({ resume }: ResumeEditorProps) {
         ? String(resume.expectedSalary)
         : "",
       employmentType: resume.employmentType ?? "",
-      skills: resume.skills.length ? resume.skills : ["Коммуникация"],
+      skills: resume.skills.length
+        ? resume.skills.map((item) => item.skill)
+        : ["Коммуникация"],
       education: resume.education.length
         ? resume.education.map((item) => ({
             institution: item.institution,

--- a/src/app/employer/dashboard/application-status-controls.tsx
+++ b/src/app/employer/dashboard/application-status-controls.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useTransition } from "react";
+
+import { updateApplicationStatus } from "@/shared/actions";
+import { Badge, Select } from "@/shared/ui";
+
+const statusOptions = [
+  { value: "pending", label: "На рассмотрении" },
+  { value: "invited", label: "Пригласить" },
+  { value: "rejected", label: "Отклонить" },
+  { value: "hired", label: "Принят" },
+];
+
+interface ApplicationStatusControlsProps {
+  applicationId: number;
+  currentStatus: "pending" | "invited" | "rejected" | "hired";
+}
+
+export function ApplicationStatusControls({
+  applicationId,
+  currentStatus,
+}: ApplicationStatusControlsProps) {
+  const [isPending, startTransition] = useTransition();
+
+  const changeStatus = (status: string) => {
+    if (!status || status === currentStatus) return;
+    startTransition(async () => {
+      await updateApplicationStatus({
+        applicationId,
+        status: status as "pending" | "invited" | "rejected" | "hired",
+      });
+    });
+  };
+
+  return (
+    <div className="flex flex-col items-end gap-2 md:flex-row md:items-center">
+      <Select
+        className="md:w-44"
+        label="Статус отклика"
+        options={statusOptions}
+        value={currentStatus}
+        onChange={(event) => changeStatus(event.target.value)}
+        aria-label="Изменить статус отклика"
+      />
+      {isPending && <Badge variant="neutral">Обновляем...</Badge>}
+    </div>
+  );
+}

--- a/src/app/employer/dashboard/page.tsx
+++ b/src/app/employer/dashboard/page.tsx
@@ -1,9 +1,12 @@
+import Link from "next/link";
 import { redirect } from "next/navigation";
 
 import { getServerAuthSession } from "@/shared/auth/session";
 import prisma from "@/shared/prisma";
-import { Badge, Card, EmptyState, StatsCard } from "@/shared/ui";
+import { Badge, Button, Card, EmptyState, StatsCard } from "@/shared/ui";
 import { formatCurrency, formatDate } from "@/shared/lib/utils";
+
+import { ApplicationStatusControls } from "./application-status-controls";
 
 async function getEmployerData(userId: number) {
   const [vacancies, applications, notifications] = await Promise.all([
@@ -71,6 +74,28 @@ export default async function EmployerDashboardPage() {
         />
       </div>
 
+      <Card className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold text-slate-900">
+            Создание вакансий
+          </h2>
+          <p className="text-sm text-slate-500">
+            Публикуйте новые предложения, чтобы быстрее находить кандидатов.
+          </p>
+        </div>
+        <div className="flex flex-col items-end gap-2 text-sm">
+          <Button asChild size="lg">
+            <Link href="/employer/vacancies/new">Создать вакансию</Link>
+          </Button>
+          <Link
+            href="/employer/vacancies"
+            className="text-xs font-medium text-slate-500 transition hover:text-slate-700"
+          >
+            Перейти к списку
+          </Link>
+        </div>
+      </Card>
+
       <Card className="space-y-4">
         <div>
           <h2 className="text-xl font-semibold text-slate-900">Уведомления</h2>
@@ -130,7 +155,7 @@ export default async function EmployerDashboardPage() {
                 key={application.id}
                 className="rounded-2xl border border-slate-200 p-4"
               >
-                <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
                   <div>
                     <h3 className="text-lg font-semibold text-slate-900">
                       {application.vacancy.title}
@@ -143,23 +168,31 @@ export default async function EmployerDashboardPage() {
                       {formatDate(application.createdAt)}
                     </p>
                   </div>
-                  <Badge
-                    variant={
-                      application.status === "invited"
-                        ? "success"
-                        : application.status === "rejected"
-                          ? "danger"
-                          : "neutral"
-                    }
-                  >
-                    {application.status === "pending"
-                      ? "На рассмотрении"
-                      : application.status === "invited"
-                        ? "Приглашён"
-                        : application.status === "rejected"
-                          ? "Отказ"
-                          : "Трудоустроен"}
-                  </Badge>
+                  <div className="flex flex-col items-end gap-2">
+                    <Badge
+                      variant={
+                        application.status === "invited"
+                          ? "success"
+                          : application.status === "rejected"
+                            ? "danger"
+                            : application.status === "hired"
+                              ? "success"
+                              : "neutral"
+                      }
+                    >
+                      {application.status === "pending"
+                        ? "На рассмотрении"
+                        : application.status === "invited"
+                          ? "Приглашён"
+                          : application.status === "rejected"
+                            ? "Отказ"
+                            : "Трудоустроен"}
+                    </Badge>
+                    <ApplicationStatusControls
+                      applicationId={application.id}
+                      currentStatus={application.status}
+                    />
+                  </div>
                 </div>
               </div>
             ))}

--- a/src/shared/actions/resume.ts
+++ b/src/shared/actions/resume.ts
@@ -99,4 +99,5 @@ export async function saveResumeAction(data: unknown) {
 
   revalidatePath("/applicant/dashboard");
   revalidatePath("/applicant/resume/edit");
+  revalidatePath("/resumes/search");
 }

--- a/src/shared/actions/vacancy.ts
+++ b/src/shared/actions/vacancy.ts
@@ -58,10 +58,12 @@ export async function createVacancyAction(data: unknown) {
 
   revalidatePath("/employer/dashboard");
   revalidatePath("/employer/vacancies");
+  revalidatePath("/jobs/search");
   redirect("/employer/vacancies");
 }
 
 export async function toggleVacancyStatus(id: number, isActive: boolean) {
   await prisma.vacancy.update({ where: { id }, data: { isActive } });
   revalidatePath("/employer/vacancies");
+  revalidatePath("/jobs/search");
 }


### PR DESCRIPTION
## Summary
- prevent duplicate applications, reuse existing invites, and add an action for candidates to respond
- expose UI controls so employers can update application statuses and applicants can accept or decline interviews
- keep dashboards in sync via additional revalidation and notifications
- surface vacancy creation entry points on the employer dashboard and refresh job listings after state changes
- allow applicants to initialize and edit resumes from their dashboard while keeping resume search results fresh

## Testing
- pnpm test integration/application.test.ts -- --runInBand *(fails: Cannot find module '.prisma/client/default' in test environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e626647f1c8329b893ffd0d7cfd11a